### PR TITLE
Configure MongoDB to run locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,9 @@ lint:
 
 test:
 	$(call run, npm run test)
+
+start-mongodb:
+	docker compose up -d mongodb
+
+stop-mongodb:
+	docker compose down mongodb

--- a/README.md
+++ b/README.md
@@ -23,3 +23,41 @@
 ```shell
 make up
 ```
+
+# MongoDB Setup and Run
+
+## Prerequisites
+
+- Ensure MongoDB is installed on your local machine. You can download and install it from the official MongoDB website.
+
+## Configuration
+
+1. Update the `.env` file in the `app` directory with your MongoDB credentials. For example:
+
+   ```shell
+   DB_HOST=localhost
+   DB_PORT=27017
+   DB_USER=yourUsername
+   DB_PASS=yourPassword
+   DB_NAME=yourDatabaseName
+   ```
+
+2. Ensure the MongoDB connection URI is correctly set in `app/db/index.ts`. The URI should be `mongodb://localhost:27017` if you are running MongoDB locally.
+
+## Running MongoDB
+
+1. Start your MongoDB server by running the `mongod` command in your terminal.
+
+2. Use the provided `Makefile` to set up and run your application. You can use the `make up` command to start the application.
+
+3. To start the MongoDB service, use the following command:
+
+   ```shell
+   make start-mongodb
+   ```
+
+4. To stop the MongoDB service, use the following command:
+
+   ```shell
+   make stop-mongodb
+   ```

--- a/app/db/index.ts
+++ b/app/db/index.ts
@@ -1,6 +1,6 @@
 import { MongoClient } from 'mongodb';
 
-const uri = process.env.DB_HOST;
+const uri = 'mongodb://localhost:27017';
 const options = {
   useNewUrlParser: true,
   useUnifiedTopology: true,
@@ -23,5 +23,11 @@ if (process.env.NODE_ENV === 'development') {
   client = new MongoClient(uri, options);
   clientPromise = client.connect();
 }
+
+clientPromise.then(() => {
+  console.log('Connected to MongoDB successfully');
+}).catch((err) => {
+  console.error('Failed to connect to MongoDB', err);
+});
 
 export default clientPromise;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,13 @@ services:
       BIND_HOST: 0.0.0.0
       GOOGLE_APPLICATION_CREDENTIALS: './application_default_credentials.json'
 
+  mongodb:
+    image: mongo:latest
+    ports:
+      - 27017:27017
+    volumes:
+      - mongo_data:/data/db
+
 volumes:
   reactflow_node_modules:
+  mongo_data:


### PR DESCRIPTION
Add MongoDB setup and configuration for local development.

* **docker-compose.yml**
  - Add MongoDB service with image `mongo:latest`.
  - Set ports for MongoDB service to `27017:27017`.
  - Add a volume for MongoDB data persistence.

* **Makefile**
  - Add `start-mongodb` target to start MongoDB service.
  - Add `stop-mongodb` target to stop MongoDB service.

* **README.md**
  - Add instructions for setting up and running MongoDB locally.
  - Include commands to start and stop MongoDB service using the `Makefile`.

* **app/db/index.ts**
  - Update MongoDB connection URI to `mongodb://localhost:27017`.
  - Add connection status check to ensure MongoDB is running locally.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogatakanori/react-flow/pull/2?shareId=d37f1bc9-b577-4c69-a406-ef69274c0774).